### PR TITLE
Add Kirill Müller (aut) and Nadine Hussein (ctb)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0001-7388-1222")),
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-7683-4592")),
+    person("Kirill", "Müller", role = "aut",
+           comment = c(ORCID = "0000-0002-1416-3412")),
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0003-4757-117X"))
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,9 @@ Authors@R: c(
     person("Kirill", "Müller", role = "aut",
            comment = c(ORCID = "0000-0002-1416-3412")),
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cph"),
-           comment = c(ORCID = "0000-0003-4757-117X"))
+           comment = c(ORCID = "0000-0003-4757-117X")),
+    person("Nadine", "Hussein", role = "ctb",
+           comment = c(ORCID = "0000-0003-4470-8361"))
   )
 Description: Asks Yes-No questions with variable or custom responses.
 License: MIT + file LICENSE


### PR DESCRIPTION
## Summary

Updates `DESCRIPTION` authorship to reflect git history:

- Adds **Kirill Müller** (ORCID 0000-0002-1416-3412) as an author (`aut`).
- Adds **Nadine Hussein** (ORCID 0000-0003-4470-8361) as a contributor (`ctb`).

## Change

- `DESCRIPTION` — added two `person()` entries, matching the file's `Authors@R` formatting. No other files changed.

```
person("Kirill", "Müller", role = "aut",
       comment = c(ORCID = "0000-0002-1416-3412")),
...
person("Nadine", "Hussein", role = "ctb",
       comment = c(ORCID = "0000-0003-4470-8361"))
```

## Rationale

A review of the git history found both contributed but were absent from `Authors@R`:

- **Kirill Müller** — 62 commits (33% of the 188 total), +2,920 / -734 lines (33% of lines added). This is an author-level contribution, consistent with how Kirill is already credited as `aut` on other Poisson Consulting CRAN packages (chk, nlist, term, universals, hmstimer, mcmcderive).
- **Nadine Hussein** — 11 commits (~6%), credited as `ctb`.

## Notes

- Contribution figures come from `git`/GitHub contributor statistics; commit and line counts are a proxy and were reviewed for substance.
- The updated `Authors@R` was verified to parse via `utils::as.person()`.
